### PR TITLE
Group link is relative

### DIFF
--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -54,7 +54,7 @@
         {{ end }}
       </div>
 
-      {{ $groupLink :=  .CurrentSection.Permalink }}
+      {{ $groupLink :=  .CurrentSection.RelPermalink }}
       <div class="pt-6 mt-8">
         <h3 class="text-2xl font-extrabold text-gray-900">Organizer details</h3>
         {{ with .CurrentSection.Params }}


### PR DESCRIPTION
Changing this so clicking the group link works on preview builds. Otherwise we get sent to muscat-tech.org