### PR TITLE
remove console.log from head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,7 +41,6 @@
                   end: event.endDate,
                   url: event.eventUrl,
                 }));
-                console.log(events, fullCalendarEvents);
                 successCallback(fullCalendarEvents);
               })
               .catch(failureCallback);


### PR DESCRIPTION
Closes #22

There were two `console.log` calls in the project. One of them in the head.html file which I removed, and the other in the `build.js` file. I didn't remove the one in `build.js` as they're called only when running `yarn build`, and it makes sense to have a log in that function.